### PR TITLE
Added support for Oppo Color OS 5.2 (Android 8.1) + Color OS 6 (Android 9) [Rx17 Neo - CPH1893 / Rx17 Pro - CPH1877]

### DIFF
--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -4,7 +4,9 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
+import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import java.util.*
 
 class AutoStartPermissionHelper private constructor() {
@@ -56,6 +58,9 @@ class AutoStartPermissionHelper private constructor() {
     private val PACKAGE_OPPO_COMPONENT = "com.coloros.safecenter.permission.startup.StartupAppListActivity"
     private val PACKAGE_OPPO_COMPONENT_FALLBACK = "com.oppo.safe.permission.startup.StartupAppListActivity"
     private val PACKAGE_OPPO_COMPONENT_FALLBACK_A = "com.coloros.safecenter.startupapp.StartupAppListActivity"
+    private val OPPO_AUTOSTART_IN_APP_INFO_SUPPORTED_DEVICES = arrayOf(
+        "CPH1893", "CPH1877" //Rx17 Neo, Rx17 Pro
+    )
 
     /**
      * Vivo
@@ -94,7 +99,6 @@ class AutoStartPermissionHelper private constructor() {
             PACKAGE_OPPO_FALLBACK, PACKAGE_VIVO_MAIN, PACKAGE_VIVO_FALLBACK, PACKAGE_NOKIA_MAIN, PACKAGE_HUAWEI_MAIN, PACKAGE_SAMSUNG_MAIN, PACKAGE_ONE_PLUS_MAIN)
 
     fun getAutoStartPermission(context: Context): Boolean {
-
         when (Build.BRAND.toLowerCase(Locale.getDefault())) {
 
             BRAND_ASUS -> return autoStartAsus(context)
@@ -240,6 +244,13 @@ class AutoStartPermissionHelper private constructor() {
                     }
                 }
             }
+        } else if (OPPO_AUTOSTART_IN_APP_INFO_SUPPORTED_DEVICES.contains(Build.DEVICE)
+                   || OPPO_AUTOSTART_IN_APP_INFO_SUPPORTED_DEVICES.contains(Build.PRODUCT)) {
+            val i = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            i.addCategory(Intent.CATEGORY_DEFAULT)
+            i.data = Uri.parse("package:${context.packageName}")
+            context.startActivity(i)
+            return true
         } else {
             return false
         }

--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -58,9 +58,6 @@ class AutoStartPermissionHelper private constructor() {
     private val PACKAGE_OPPO_COMPONENT = "com.coloros.safecenter.permission.startup.StartupAppListActivity"
     private val PACKAGE_OPPO_COMPONENT_FALLBACK = "com.oppo.safe.permission.startup.StartupAppListActivity"
     private val PACKAGE_OPPO_COMPONENT_FALLBACK_A = "com.coloros.safecenter.startupapp.StartupAppListActivity"
-    private val OPPO_AUTOSTART_IN_APP_INFO_SUPPORTED_DEVICES = arrayOf(
-        "CPH1893", "CPH1877" //Rx17 Neo, Rx17 Pro
-    )
 
     /**
      * Vivo
@@ -240,22 +237,27 @@ class AutoStartPermissionHelper private constructor() {
                         startIntent(context, PACKAGE_OPPO_MAIN, PACKAGE_OPPO_COMPONENT_FALLBACK_A)
                     } catch (exx: Exception) {
                         exx.printStackTrace()
-                        return false
+                        return launchOppoAppInfo(context)
                     }
                 }
             }
-        } else if (OPPO_AUTOSTART_IN_APP_INFO_SUPPORTED_DEVICES.contains(Build.DEVICE)
-                   || OPPO_AUTOSTART_IN_APP_INFO_SUPPORTED_DEVICES.contains(Build.PRODUCT)) {
+        } else {
+            return launchOppoAppInfo(context)
+        }
+        return true
+    }
+
+    private fun launchOppoAppInfo(context: Context): Boolean {
+        return try {
             val i = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
             i.addCategory(Intent.CATEGORY_DEFAULT)
             i.data = Uri.parse("package:${context.packageName}")
             context.startActivity(i)
-            return true
-        } else {
-            return false
+            true
+        } catch (exx: Exception) {
+            exx.printStackTrace()
+            false
         }
-
-        return true
     }
 
     private fun autoStartVivo(context: Context): Boolean {


### PR DESCRIPTION
Added support for Oppo Rx17 Neo and Rx17 Pro on ColorOS 5.2. These devices[ do have the package StartupManager ](https://drive.google.com/file/d/1zRlXeR22lIO8MTLgrabSVb6nTkSUoEgE/view?usp=sharing) used in the library code (Phone Manager, Privacy, Startup Manager) but several new Oppo measures prevent the library from working.

1. trying to launch the installed startup manager package (com.coloros.safecenter/.startupapp.StartupAppListActivity) fails as it now states "[requires oppo.permission.OPPO_COMPONENT_SAFE](https://drive.google.com/file/d/1FWIsAjxvyYd24-bxEzm0mRAzZvvmS0rZ/view?usp=sharing)"
2. checking if package exists will return false even if it is present, which is probably again down to Oppo permission requirement.

However the Auto Start switch is also shown within the app info screen. Sadly I can't make it highlight the "Auto Start" switch row but we can take the user there at least. 
Device info: 
Oppo Rx17 Neo (CPH1893) / Rx17 Pro (CPH1877), Color OS 5.2 (Android 8.1). 
Firmware links:
[Oppo Rx17 Neo (CPH1893)](https://oppo-uk.custhelp.com/app/software_update_detail/p_name/RX17%20Neo)
[Oppo Rx17 Pro (CPH1877)](https://oppo-uk.custhelp.com/app/software_update_detail/p_name/RX17%20Pro)

I've only tested on Rx17 Neo, ColorOS 5.2 (firmware CPH1893EX_11_A.16)
Video showing test results (before and after fix)
https://drive.google.com/drive/folders/1fEiq9UwKLW5jTAqUWyYy96lHMsZ2CDSI
However this fix should also work on higher versions of ColorOS. 

Update: Received [confirmation](https://github.com/judemanutd/AutoStarter/issues/14#issuecomment-678341935) "Allow auto start" switch is present App Info in Color OS 6.0.1 (A1k CPH1923) so can treat as a forward trend in Color OS.