### PR TITLE
Log device info to logcat in test app.

### DIFF
--- a/app/src/main/java/com/judemanutd/autostarterexample/MainActivity.kt
+++ b/app/src/main/java/com/judemanutd/autostarterexample/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.judemanutd.autostarterexample
 
+import android.os.Build
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.util.Log
 import android.widget.Button
 import android.widget.Toast
 import com.judemanutd.autostarter.AutoStartPermissionHelper
@@ -12,16 +14,33 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        logDeviceInfo()
+
         val button = findViewById<Button>(R.id.button)
         button.setOnClickListener {
-
+            val autoStartAvailable = AutoStartPermissionHelper.getInstance().isAutoStartPermissionAvailable(this)
             val success = AutoStartPermissionHelper.getInstance().getAutoStartPermission(this@MainActivity)
             var message = "Failed"
-            if (success) message = "Successfull"
+            if (success) message = "Successful"
 
-            Toast.makeText(this@MainActivity, "Action $message", Toast.LENGTH_SHORT).show()
-
+            Toast.makeText(this@MainActivity, "Supports AutoStart: $autoStartAvailable, Action $message", Toast.LENGTH_SHORT).show()
         }
+    }
 
+    private fun logDeviceInfo() {
+        val tag = "DeviceInfo"
+        Log.w(tag, "Board: ${Build.BOARD}")
+        Log.w(tag, "Brand: ${Build.BRAND}")
+        Log.w(tag, "Device: ${Build.DEVICE}")
+        Log.w(tag, "Display: ${Build.DISPLAY}")
+        Log.w(tag, "Hardware: ${Build.HARDWARE}")
+        Log.w(tag, "Manufacturer: ${Build.MANUFACTURER}")
+        Log.w(tag, "Product: ${Build.PRODUCT}")
+        Log.w(tag, "Version.Release: ${Build.VERSION.RELEASE}")
+        Log.w(tag, "Version.Codename: ${Build.VERSION.CODENAME}")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Log.w(tag, "Version.BaseOS: ${Build.VERSION.BASE_OS}")
+            Log.w(tag, "Version.SecurityPatch: ${Build.VERSION.SECURITY_PATCH}")
+        }
     }
 }


### PR DESCRIPTION
Helpful to log device info to help create new filters for the library (in the case it's model/firmware specific like Oppo PR #51 )
Also updated Toast to show isAutoStartPermissionAvailable() result.