### PR TITLE
Lowercase locale

### DIFF
--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -95,7 +95,7 @@ class AutoStartPermissionHelper private constructor() {
 
     fun getAutoStartPermission(context: Context): Boolean {
 
-        when (Build.BRAND.toLowerCase(Locale.getDefault())) {
+        when (Build.BRAND.toLowerCase()) {
 
             BRAND_ASUS -> return autoStartAsus(context)
 


### PR DESCRIPTION
There is no need to use locale when getting device name. Plus it makes problems when converting Turkish I character