### PR TITLE
Add Xiaomi sub-brand Poco

### DIFF
--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -13,6 +13,7 @@ class AutoStartPermissionHelper private constructor() {
      * Xiaomi
      */
     private val BRAND_XIAOMI = "xiaomi"
+    private val BRAND_XIAOMI_POCO = "poco"
     private val BRAND_XIAOMI_REDMI = "redmi"
     private val PACKAGE_XIAOMI_MAIN = "com.miui.securitycenter"
     private val PACKAGE_XIAOMI_COMPONENT = "com.miui.permcenter.autostart.AutoStartManagementActivity"
@@ -99,7 +100,7 @@ class AutoStartPermissionHelper private constructor() {
 
             BRAND_ASUS -> return autoStartAsus(context)
 
-            BRAND_XIAOMI, BRAND_XIAOMI_REDMI -> return autoStartXiaomi(context)
+            BRAND_XIAOMI, BRAND_XIAOMI_POCO, BRAND_XIAOMI_REDMI -> return autoStartXiaomi(context)
 
             BRAND_LETV -> return autoStartLetv(context)
 


### PR DESCRIPTION
POCO is a Xiaomi sub-brand that uses the same package main and component as the original brand.

I confirmed the package names from a Poco X3 model with MIUI 12.0.5 running in it.