### PR TITLE
Several Improvements

### DIFF
--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -95,6 +95,7 @@ class AutoStartPermissionHelper private constructor() {
     private val BRAND_ONE_PLUS = "oneplus"
     private val PACKAGE_ONE_PLUS_MAIN = "com.oneplus.security"
     private val PACKAGE_ONE_PLUS_COMPONENT = "com.oneplus.security.chainlaunch.view.ChainLaunchAppListActivity"
+    private val PACKAGE_ONE_PLUS_ACTION = "com.android.settings.action.BACKGROUND_OPTIMIZE"
 
     private val PACKAGES_TO_CHECK_FOR_PERMISSION = listOf(
             PACKAGE_ASUS_MAIN,
@@ -295,7 +296,7 @@ class AutoStartPermissionHelper private constructor() {
                 listOf(PACKAGE_ONE_PLUS_MAIN),
                 listOf(getIntent(PACKAGE_ONE_PLUS_MAIN, PACKAGE_ONE_PLUS_COMPONENT, newTask)),
                 open
-        )
+        ) || autoStartFromAction(context, listOf(getIntentFromAction(PACKAGE_ONE_PLUS_ACTION, newTask)), open)
     }
 
     @Throws(Exception::class)
@@ -339,6 +340,19 @@ class AutoStartPermissionHelper private constructor() {
     private fun getIntent(packageName: String, componentName: String, newTask: Boolean): Intent {
         return Intent().apply {
             component = ComponentName(packageName, componentName)
+            if (newTask) flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+    }
+
+    /**
+     * Generates an intent with the passed action
+     * @param intentAction
+     *
+     * @return the intent generated
+     */
+    private fun getIntentFromAction(intentAction: String, newTask: Boolean): Intent {
+        return Intent().apply {
+            action = "com.android.settings.action.BACKGROUND_OPTIMIZE"
             if (newTask) flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
     }
@@ -403,6 +417,20 @@ class AutoStartPermissionHelper private constructor() {
             if (open) openAutoStartScreen(context, intents)
             else areActivitiesFound(context, intents)
         } else false
+    }
+
+    /**
+     * Will trigger the common autostart permission logic. If [open] is true it will attempt to open the specific
+     * manufacturer setting screen, otherwise it will just check for its existence
+     *
+     * @param context
+     * @param intentActions, list of known intent actions that open the corresponding manufacturer settings screens
+     * @param open, if true it will attempt to open the settings screen, otherwise it just check its existence
+     * @return true if the screen was opened or exists, false if it doesn't exist or could not be opened
+     */
+    private fun autoStartFromAction(context: Context, intentActions: List<Intent>, open: Boolean): Boolean {
+        return if (open) openAutoStartScreen(context, intentActions)
+        else areActivitiesFound(context, intentActions)
     }
 }
 

--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -311,9 +311,10 @@ class AutoStartPermissionHelper private constructor() {
 
     companion object {
 
-        @JvmStatic
+        private val myInstance by lazy { AutoStartPermissionHelper() }
+
         fun getInstance(): AutoStartPermissionHelper {
-            return AutoStartPermissionHelper()
+            return myInstance
         }
     }
 

--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -97,20 +97,8 @@ class AutoStartPermissionHelper private constructor() {
     private val PACKAGE_ONE_PLUS_COMPONENT = "com.oneplus.security.chainlaunch.view.ChainLaunchAppListActivity"
     private val PACKAGE_ONE_PLUS_ACTION = "com.android.settings.action.BACKGROUND_OPTIMIZE"
 
-    private val PACKAGES_TO_CHECK_FOR_PERMISSION = listOf(
-            PACKAGE_ASUS_MAIN,
-            PACKAGE_XIAOMI_MAIN,
-            PACKAGE_LETV_MAIN,
-            PACKAGE_HONOR_MAIN,
-            PACKAGE_OPPO_MAIN,
-            PACKAGE_OPPO_FALLBACK,
-            PACKAGE_VIVO_MAIN,
-            PACKAGE_VIVO_FALLBACK,
-            PACKAGE_NOKIA_MAIN,
-            PACKAGE_HUAWEI_MAIN,
-            PACKAGE_SAMSUNG_MAIN,
-            PACKAGE_ONE_PLUS_MAIN
-    )
+    private val PACKAGES_TO_CHECK_FOR_PERMISSION = listOf(PACKAGE_ASUS_MAIN, PACKAGE_XIAOMI_MAIN, PACKAGE_LETV_MAIN, PACKAGE_HONOR_MAIN, PACKAGE_OPPO_MAIN,
+            PACKAGE_OPPO_FALLBACK, PACKAGE_VIVO_MAIN, PACKAGE_VIVO_FALLBACK, PACKAGE_NOKIA_MAIN, PACKAGE_HUAWEI_MAIN, PACKAGE_SAMSUNG_MAIN, PACKAGE_ONE_PLUS_MAIN)
 
     /**
      * It will attempt to open the specific manufacturer settings screen with the autostart permission
@@ -340,20 +328,21 @@ class AutoStartPermissionHelper private constructor() {
     private fun getIntent(packageName: String, componentName: String, newTask: Boolean): Intent {
         return Intent().apply {
             component = ComponentName(packageName, componentName)
-            if (newTask) flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            if (newTask) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
     }
 
     /**
      * Generates an intent with the passed action
      * @param intentAction
+     * @param newTask
      *
      * @return the intent generated
      */
     private fun getIntentFromAction(intentAction: String, newTask: Boolean): Intent {
         return Intent().apply {
-            action = "com.android.settings.action.BACKGROUND_OPTIMIZE"
-            if (newTask) flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            action = intentAction
+            if (newTask) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
     }
 

--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -154,15 +154,18 @@ class AutoStartPermissionHelper private constructor() {
      * Checks whether the autostart permission is present in the manufacturer and supported by the library
      *
      * @param context
+     * @param onlyIfSupported if true, the method will only return true if the screen is supported by the library.
+     *          If false, the method will return true as long as the permission exist even if the screen is not supported
+     *          by the library.
      * @return true if autostart permission is present in the manufacturer and supported by the library, false otherwise
      */
-    fun isAutoStartPermissionAvailable(context: Context): Boolean {
+    fun isAutoStartPermissionAvailable(context: Context, onlyIfSupported: Boolean = false): Boolean {
         val packages: List<ApplicationInfo>
         val pm = context.packageManager
         packages = pm.getInstalledApplications(0)
         for (packageInfo in packages) {
             if (PACKAGES_TO_CHECK_FOR_PERMISSION.contains(packageInfo.packageName)
-                    && getAutoStartPermission(context, open = false, newTask = false)
+                    && (!onlyIfSupported || getAutoStartPermission(context, open = false))
             ) return true
         }
         return false

--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -87,7 +87,7 @@ class AutoStartPermissionHelper private constructor() {
     private val PACKAGE_SAMSUNG_MAIN = "com.samsung.android.lool"
     private val PACKAGE_SAMSUNG_COMPONENT = "com.samsung.android.sm.ui.battery.BatteryActivity"
     private val PACKAGE_SAMSUNG_COMPONENT_2 = "com.samsung.android.sm.battery.ui.usage.CheckableAppListActivity"
-    private val PACKAGE_SAMSUNG_COMPONENT_3 = "com.samsung.android.sm.battery.ui.usage.CheckableAppListActivity"
+    private val PACKAGE_SAMSUNG_COMPONENT_3 = "com.samsung.android.sm.battery.ui.BatteryActivity"
 
     /***
      * One plus

--- a/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
+++ b/autostarter/src/main/java/com/judemanutd/autostarter/AutoStartPermissionHelper.kt
@@ -117,31 +117,32 @@ class AutoStartPermissionHelper private constructor() {
      *
      * @param context
      * @param open, if true it will attempt to open the activity, otherwise it will just check its existence
+     * @param newTask, if true when the activity is attempted to be opened it will add FLAG_ACTIVITY_NEW_TASK to the intent
      * @return true if the activity was opened or is confirmed that it exists (depending on [open]]), false otherwise
      */
-    fun getAutoStartPermission(context: Context, open: Boolean = true): Boolean {
+    fun getAutoStartPermission(context: Context, open: Boolean = true, newTask: Boolean = false): Boolean {
 
         when (Build.BRAND.toLowerCase(Locale.ROOT)) {
 
-            BRAND_ASUS -> return autoStartAsus(context, open)
+            BRAND_ASUS -> return autoStartAsus(context, open, newTask)
 
-            BRAND_XIAOMI, BRAND_XIAOMI_POCO, BRAND_XIAOMI_REDMI -> return autoStartXiaomi(context, open)
+            BRAND_XIAOMI, BRAND_XIAOMI_POCO, BRAND_XIAOMI_REDMI -> return autoStartXiaomi(context, open, newTask)
 
-            BRAND_LETV -> return autoStartLetv(context, open)
+            BRAND_LETV -> return autoStartLetv(context, open, newTask)
 
-            BRAND_HONOR -> return autoStartHonor(context, open)
+            BRAND_HONOR -> return autoStartHonor(context, open, newTask)
 
-            BRAND_HUAWEI -> return autoStartHuawei(context, open)
+            BRAND_HUAWEI -> return autoStartHuawei(context, open, newTask)
 
-            BRAND_OPPO -> return autoStartOppo(context, open)
+            BRAND_OPPO -> return autoStartOppo(context, open, newTask)
 
-            BRAND_VIVO -> return autoStartVivo(context, open)
+            BRAND_VIVO -> return autoStartVivo(context, open, newTask)
 
-            BRAND_NOKIA -> return autoStartNokia(context, open)
+            BRAND_NOKIA -> return autoStartNokia(context, open, newTask)
 
-            BRAND_SAMSUNG -> return autoStartSamsung(context, open)
+            BRAND_SAMSUNG -> return autoStartSamsung(context, open, newTask)
 
-            BRAND_ONE_PLUS -> return autoStartOnePlus(context, open)
+            BRAND_ONE_PLUS -> return autoStartOnePlus(context, open, newTask)
 
             else -> {
                 return false
@@ -161,79 +162,79 @@ class AutoStartPermissionHelper private constructor() {
         packages = pm.getInstalledApplications(0)
         for (packageInfo in packages) {
             if (PACKAGES_TO_CHECK_FOR_PERMISSION.contains(packageInfo.packageName)
-                    && getAutoStartPermission(context, false)
+                    && getAutoStartPermission(context, open = false, newTask = false)
             ) return true
         }
         return false
     }
 
-    private fun autoStartXiaomi(context: Context, open: Boolean): Boolean {
+    private fun autoStartXiaomi(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_XIAOMI_MAIN),
-                listOf(getIntent(PACKAGE_XIAOMI_MAIN, PACKAGE_XIAOMI_COMPONENT)),
+                listOf(getIntent(PACKAGE_XIAOMI_MAIN, PACKAGE_XIAOMI_COMPONENT, newTask)),
                 open
         )
     }
 
-    private fun autoStartAsus(context: Context, open: Boolean): Boolean {
+    private fun autoStartAsus(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_ASUS_MAIN),
                 listOf(
-                        getIntent(PACKAGE_ASUS_MAIN, PACKAGE_ASUS_COMPONENT),
-                        getIntent(PACKAGE_ASUS_MAIN, PACKAGE_ASUS_COMPONENT_FALLBACK)
+                        getIntent(PACKAGE_ASUS_MAIN, PACKAGE_ASUS_COMPONENT, newTask),
+                        getIntent(PACKAGE_ASUS_MAIN, PACKAGE_ASUS_COMPONENT_FALLBACK, newTask)
                 ),
                 open
         )
     }
 
-    private fun autoStartLetv(context: Context, open: Boolean): Boolean {
+    private fun autoStartLetv(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_LETV_MAIN),
-                listOf(getIntent(PACKAGE_LETV_MAIN, PACKAGE_LETV_COMPONENT)),
+                listOf(getIntent(PACKAGE_LETV_MAIN, PACKAGE_LETV_COMPONENT, newTask)),
                 open
         )
     }
 
-    private fun autoStartHonor(context: Context, open: Boolean): Boolean {
+    private fun autoStartHonor(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_HONOR_MAIN),
-                listOf(getIntent(PACKAGE_HONOR_MAIN, PACKAGE_HONOR_COMPONENT)),
+                listOf(getIntent(PACKAGE_HONOR_MAIN, PACKAGE_HONOR_COMPONENT, newTask)),
                 open
         )
     }
 
-    private fun autoStartHuawei(context: Context, open: Boolean): Boolean {
+    private fun autoStartHuawei(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_HUAWEI_MAIN),
                 listOf(
-                        getIntent(PACKAGE_HUAWEI_MAIN, PACKAGE_HUAWEI_COMPONENT),
-                        getIntent(PACKAGE_HUAWEI_MAIN, PACKAGE_HUAWEI_COMPONENT_FALLBACK)
+                        getIntent(PACKAGE_HUAWEI_MAIN, PACKAGE_HUAWEI_COMPONENT, newTask),
+                        getIntent(PACKAGE_HUAWEI_MAIN, PACKAGE_HUAWEI_COMPONENT_FALLBACK, newTask)
                 ),
                 open
         )
     }
 
-    private fun autoStartOppo(context: Context, open: Boolean): Boolean {
+    private fun autoStartOppo(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return if (autoStart(
                         context,
                         listOf(PACKAGE_OPPO_MAIN, PACKAGE_OPPO_FALLBACK),
                         listOf(
-                                getIntent(PACKAGE_OPPO_MAIN, PACKAGE_OPPO_COMPONENT),
-                                getIntent(PACKAGE_OPPO_FALLBACK, PACKAGE_OPPO_COMPONENT_FALLBACK),
-                                getIntent(PACKAGE_OPPO_MAIN, PACKAGE_OPPO_COMPONENT_FALLBACK_A)
+                                getIntent(PACKAGE_OPPO_MAIN, PACKAGE_OPPO_COMPONENT, newTask),
+                                getIntent(PACKAGE_OPPO_FALLBACK, PACKAGE_OPPO_COMPONENT_FALLBACK, newTask),
+                                getIntent(PACKAGE_OPPO_MAIN, PACKAGE_OPPO_COMPONENT_FALLBACK_A, newTask)
                         ),
                         open
                 )
         ) true
-        else launchOppoAppInfo(context, open)
+        else launchOppoAppInfo(context, open, newTask)
     }
 
-    private fun launchOppoAppInfo(context: Context, open: Boolean): Boolean {
+    private fun launchOppoAppInfo(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return try {
             val i = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
             i.addCategory(Intent.CATEGORY_DEFAULT)
@@ -250,46 +251,46 @@ class AutoStartPermissionHelper private constructor() {
         }
     }
 
-    private fun autoStartVivo(context: Context, open: Boolean): Boolean {
+    private fun autoStartVivo(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_VIVO_MAIN, PACKAGE_VIVO_FALLBACK),
                 listOf(
-                        getIntent(PACKAGE_VIVO_MAIN, PACKAGE_VIVO_COMPONENT),
-                        getIntent(PACKAGE_VIVO_FALLBACK, PACKAGE_VIVO_COMPONENT_FALLBACK),
-                        getIntent(PACKAGE_VIVO_MAIN, PACKAGE_VIVO_COMPONENT_FALLBACK_A)
+                        getIntent(PACKAGE_VIVO_MAIN, PACKAGE_VIVO_COMPONENT, newTask),
+                        getIntent(PACKAGE_VIVO_FALLBACK, PACKAGE_VIVO_COMPONENT_FALLBACK, newTask),
+                        getIntent(PACKAGE_VIVO_MAIN, PACKAGE_VIVO_COMPONENT_FALLBACK_A, newTask)
                 ),
                 open
         )
     }
 
-    private fun autoStartNokia(context: Context, open: Boolean): Boolean {
+    private fun autoStartNokia(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_NOKIA_MAIN),
-                listOf(getIntent(PACKAGE_NOKIA_MAIN, PACKAGE_NOKIA_COMPONENT)),
+                listOf(getIntent(PACKAGE_NOKIA_MAIN, PACKAGE_NOKIA_COMPONENT, newTask)),
                 open
         )
     }
 
-    private fun autoStartSamsung(context: Context, open: Boolean): Boolean {
+    private fun autoStartSamsung(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_SAMSUNG_MAIN),
                 listOf(
-                        getIntent(PACKAGE_SAMSUNG_MAIN, PACKAGE_SAMSUNG_COMPONENT),
-                        getIntent(PACKAGE_SAMSUNG_MAIN, PACKAGE_SAMSUNG_COMPONENT_2),
-                        getIntent(PACKAGE_SAMSUNG_MAIN, PACKAGE_SAMSUNG_COMPONENT_3)
+                        getIntent(PACKAGE_SAMSUNG_MAIN, PACKAGE_SAMSUNG_COMPONENT, newTask),
+                        getIntent(PACKAGE_SAMSUNG_MAIN, PACKAGE_SAMSUNG_COMPONENT_2, newTask),
+                        getIntent(PACKAGE_SAMSUNG_MAIN, PACKAGE_SAMSUNG_COMPONENT_3, newTask)
                 ),
                 open
         )
     }
 
-    private fun autoStartOnePlus(context: Context, open: Boolean): Boolean {
+    private fun autoStartOnePlus(context: Context, open: Boolean, newTask: Boolean): Boolean {
         return autoStart(
                 context,
                 listOf(PACKAGE_ONE_PLUS_MAIN),
-                listOf(getIntent(PACKAGE_ONE_PLUS_MAIN, PACKAGE_ONE_PLUS_COMPONENT)),
+                listOf(getIntent(PACKAGE_ONE_PLUS_MAIN, PACKAGE_ONE_PLUS_COMPONENT, newTask)),
                 open
         )
     }
@@ -328,13 +329,14 @@ class AutoStartPermissionHelper private constructor() {
      * Generates an intent with the passed package and component name
      * @param packageName
      * @param componentName
+     * @param newTask
      *
      * @return the intent generated
      */
-    private fun getIntent(packageName: String, componentName: String): Intent {
+    private fun getIntent(packageName: String, componentName: String, newTask: Boolean): Intent {
         return Intent().apply {
             component = ComponentName(packageName, componentName)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            if (newTask) flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
     }
 
@@ -400,3 +402,4 @@ class AutoStartPermissionHelper private constructor() {
         } else false
     }
 }
+


### PR DESCRIPTION
I tried to modify the minimum from the original code but some of the current issues required quite a few changes, sorry in advance for that.

1) Main change is that it checks the existence of the activities before attempting to open them. Now if the activity can't really  be opened, `getAutoStartPermission` will return false. Related issues: https://github.com/judemanutd/AutoStarter/issues/29 https://github.com/judemanutd/AutoStarter/issues/30

2) `isAutoStartPermissionAvailable` now allows the caller to only consider the permissions available if the library is able to open the corresponding settings screen (in order to avoid _false positives_). For backward compatibility with previous versions of the library, by default autostart is considered available even if the library does not support the specific screen.


3) Inverted the Huawei intents to process the newer ones first (I didn't invert the rest of the manufacturers as I can't test all of them). This fixes the known issue with Huawei P 10 Lite: https://github.com/judemanutd/AutoStarter/issues/38 [tested]


4) Use `Build.BRAND.toLowerCase(Locale.ROOT)` to avoid issues with certain languages as Turkish as mentioned here: https://github.com/judemanutd/AutoStarter/issues/66 [tested]


5) Includes `FLAG_ACTIVITY_NEW_TASK` as optional so that the library can be called outside an Activity.
Fix this: https://github.com/judemanutd/AutoStarter/issues/42 (related to PR: https://github.com/judemanutd/AutoStarter/pull/62) [Tested]


6) Add a new activity to be opened in Samsung devices.
Prioritize this one as it opens the exact Sleeping Apps setting
`com.samsung.android.lool/com.samsung.android.sm.battery.ui.usage.CheckableAppListActivity`
If that screen does not exist it will fallback to this one which opens the main battery settings
`com.samsung.android.lool/com.samsung.android.sm.battery.ui.BatteryActivity`
That should fix these issues :https://github.com/judemanutd/AutoStarter/issues/37 https://github.com/judemanutd/AutoStarter/issues/33  [Tested with Note 8, Note 9 & Note 20]

7) Handle OnePlus newer devices (via intent action `com.android.settings.action.BACKGROUND_OPTIMIZE`)
Should fix these: https://github.com/judemanutd/AutoStarter/issues/36 https://github.com/judemanutd/AutoStarter/issues/45 https://github.com/judemanutd/AutoStarter/issues/67 [Tested with OnePlus 7 pro (10), Oneplus 7T(10) & OnePlus 8(11)]
